### PR TITLE
Fix image size in content editor

### DIFF
--- a/Resources/public/css/modules/embed.css
+++ b/Resources/public/css/modules/embed.css
@@ -14,6 +14,7 @@
 
 [data-ezelement="ezembed"] .ez-embed-content {
     margin: 0;
+    max-width: 100%;
 }
 
 [data-ezelement="ezembed"] .ez-embed-content:before {


### PR DESCRIPTION
Hi,

This is a PR to fix a bug when inserting a large image in the content editor.

Before :
![ez-bug-img](https://cloud.githubusercontent.com/assets/5872294/17702693/3c8da822-63cf-11e6-8743-ebd9e2a0d2af.PNG)

After :
![ez-bug-img-fixed](https://cloud.githubusercontent.com/assets/5872294/17702696/3eebfa7e-63cf-11e6-9f68-6e097e5247ce.PNG)

Jérémy.
